### PR TITLE
chore: align event payload with tinybird

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,12 +53,10 @@ export type EventType =
 export interface EventPayload {
   id: string;
   event_type: EventType;
-  slug?: string;
+  funnel_slug?: string;
   flow_id?: string;
   step_id?: string;
-  options: Record<string, any>;
-  result?: string;
-  traits?: Record<string, any>;
+  metadata?: Record<string, any>;
   session_id: string;
   timestamp: string;
   project_key: string;


### PR DESCRIPTION
a couple of changes here that are out of scope of the initial ticket - but thought it was useful for my changes:
- session endpoint was still hitting the Nextjs API route, was very difficult to test
- certain events were still being sent to the Nextjs API routes, it was having an impact on testing
- improved the EventPayload we were sending to the Ingestion Worker to reduce data transformations in the worker